### PR TITLE
fix(トップページ): モバイル表示の場合は「もっと詳しく」ボタンを中央に表示 (#70)

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -223,10 +223,16 @@ $hero-max-height: 640px;
   &__detail-link {
     position: absolute;
     bottom: -3.25em;
-    right: 0;
+    right: 50%;
+    transform: translateX(50%);
 
     &::before {
       content: ">> ";
+    }
+
+    @include mediaquery(md) {
+      right: 0;
+      transform: none;
     }
   }
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -51,7 +51,7 @@ figure {
 figcaption {
   font-size: 0.8em;
   text-align: center;
-  margin-top: .5em;
+  margin-top: 0.5em;
 }
 
 rt {


### PR DESCRIPTION
closes #70 